### PR TITLE
Add CategoryRepositoryImpl

### DIFF
--- a/app/src/main/java/com/example/harmoney/core/di/dataModule.kt
+++ b/app/src/main/java/com/example/harmoney/core/di/dataModule.kt
@@ -6,6 +6,8 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.room.Room
 import com.example.harmoney.core.database.AppDatabase
+import com.example.harmoney.data.category.converter.CategoryDBConverter
+import com.example.harmoney.data.category.converter.CategoryDBConverterImpl
 import com.example.harmoney.data.category.dao.CategoryDao
 import com.example.harmoney.data.converters.DateConverter
 import com.example.harmoney.data.transaction.dao.TransactionDao
@@ -42,5 +44,9 @@ val dataModule = module {
 
     factory {
         DateConverter()
+    }
+
+    factory<CategoryDBConverter> {
+        CategoryDBConverterImpl()
     }
 }

--- a/app/src/main/java/com/example/harmoney/core/di/repositoryModule.kt
+++ b/app/src/main/java/com/example/harmoney/core/di/repositoryModule.kt
@@ -1,8 +1,10 @@
 package com.example.harmoney.core.di
 
+import com.example.harmoney.data.category.impl.CategoryRepositoryImpl
 import com.example.harmoney.data.settings.categorySortingMode.impl.CategorySortOptionRepositoryImpl
 import com.example.harmoney.data.settings.firstDayMonth.impl.FirstDayMonthRepositoryImpl
 import com.example.harmoney.data.settings.theme.impl.ThemeRepositoryImpl
+import com.example.harmoney.domain.category.api.reposiory.CategoryRepository
 import com.example.harmoney.domain.settings.categorySortingMode.api.repository.CategorySortOptionRepository
 import com.example.harmoney.domain.settings.period.api.repository.FirstDayMonthRepository
 import com.example.harmoney.domain.settings.theme.api.repository.ThemeRepository
@@ -19,5 +21,9 @@ val repositoryModule = module {
 
     factory<CategorySortOptionRepository> {
         CategorySortOptionRepositoryImpl(dataStore = get())
+    }
+
+    factory<CategoryRepository> {
+        CategoryRepositoryImpl(categoryDao = get(), categoryDBConverter = get())
     }
 }

--- a/app/src/main/java/com/example/harmoney/core/di/useCaseModule.kt
+++ b/app/src/main/java/com/example/harmoney/core/di/useCaseModule.kt
@@ -1,5 +1,19 @@
 package com.example.harmoney.core.di
 
+import com.example.harmoney.domain.category.api.useCase.AddCategoryUseCase
+import com.example.harmoney.domain.category.api.useCase.CheckCategoryAlreadyExistsUseCase
+import com.example.harmoney.domain.category.api.useCase.DeleteCategoryUseCase
+import com.example.harmoney.domain.category.api.useCase.GetCategoryListUseCase
+import com.example.harmoney.domain.category.api.useCase.GetCategoryUseCase
+import com.example.harmoney.domain.category.api.useCase.UpdateCategoryUseCase
+import com.example.harmoney.domain.category.api.useCase.UpdateCategoryUserOrderUseCase
+import com.example.harmoney.domain.category.impl.AddCategoryUseCaseImpl
+import com.example.harmoney.domain.category.impl.CheckCategoryAlreadyExistsUseCaseImpl
+import com.example.harmoney.domain.category.impl.DeleteCategoryUseCaseImpl
+import com.example.harmoney.domain.category.impl.GetCategoryListUseCaseImpl
+import com.example.harmoney.domain.category.impl.GetCategoryUseCaseImpl
+import com.example.harmoney.domain.category.impl.UpdateCategoryUseCaseImpl
+import com.example.harmoney.domain.category.impl.UpdateCategoryUserOrderUseCaseImpl
 import com.example.harmoney.domain.settings.categorySortingMode.api.useCase.CategorySortOptionInteractor
 import com.example.harmoney.domain.settings.categorySortingMode.impl.CategorySortOptionInteractorImpl
 import com.example.harmoney.domain.settings.period.api.useCase.FirstDayMonthInteractor
@@ -14,6 +28,8 @@ import com.example.harmoney.domain.settings.theme.impl.SetThemeUseCaseImpl
 import org.koin.dsl.module
 
 val useCaseModule = module {
+
+    // region theme
     factory<GetIsThemeDarkUseCase> {
         GetIsThemeDarkUseCaseImpl(themeRepository = get())
     }
@@ -21,7 +37,9 @@ val useCaseModule = module {
     factory<SetThemeUseCase> {
         SetThemeUseCaseImpl(themeRepository = get())
     }
+    // endregion
 
+    // region statistics periods
     factory<GetStatisticsPeriodsUseCase> {
         GetStatisticsPeriodsUseCaseImpl(repository = get(), calculator = get())
     }
@@ -29,12 +47,45 @@ val useCaseModule = module {
     factory {
         StatisticsPeriodCalculator()
     }
+    // endregion
 
+    // region first day month
     factory<FirstDayMonthInteractor> {
         FirstDayMonthInteractorImpl(repository = get())
     }
+    // endregion
 
+    // region category
     factory<CategorySortOptionInteractor> {
         CategorySortOptionInteractorImpl(repository = get())
     }
+
+    factory<AddCategoryUseCase> {
+        AddCategoryUseCaseImpl(repository = get())
+    }
+
+    factory<CheckCategoryAlreadyExistsUseCase> {
+        CheckCategoryAlreadyExistsUseCaseImpl(repository = get())
+    }
+
+    factory<DeleteCategoryUseCase> {
+        DeleteCategoryUseCaseImpl(repository = get())
+    }
+
+    factory<GetCategoryListUseCase> {
+        GetCategoryListUseCaseImpl(categoryRepository = get(), sortOptionRepository = get())
+    }
+
+    factory<GetCategoryUseCase> {
+        GetCategoryUseCaseImpl(repository = get())
+    }
+
+    factory<UpdateCategoryUseCase> {
+        UpdateCategoryUseCaseImpl(repository = get())
+    }
+
+    factory<UpdateCategoryUserOrderUseCase> {
+        UpdateCategoryUserOrderUseCaseImpl(repository = get())
+    }
+    // endregion
 }

--- a/app/src/main/java/com/example/harmoney/data/category/converter/CategoryDBConverter.kt
+++ b/app/src/main/java/com/example/harmoney/data/category/converter/CategoryDBConverter.kt
@@ -1,0 +1,12 @@
+package com.example.harmoney.data.category.converter
+
+import com.example.harmoney.data.category.entity.CategoryEntity
+import com.example.harmoney.domain.models.Category
+
+interface CategoryDBConverter {
+    fun map(category: CategoryEntity): Category
+
+    fun map(category: Category): CategoryEntity
+
+    fun map(categoryList: List<CategoryEntity>): List<Category>
+}

--- a/app/src/main/java/com/example/harmoney/data/category/converter/CategoryDBConverterImpl.kt
+++ b/app/src/main/java/com/example/harmoney/data/category/converter/CategoryDBConverterImpl.kt
@@ -1,0 +1,40 @@
+package com.example.harmoney.data.category.converter
+
+import com.example.harmoney.data.category.entity.CategoryEntity
+import com.example.harmoney.domain.models.Category
+import com.example.harmoney.domain.models.CategoryColors
+import com.example.harmoney.domain.models.CategoryIcon
+import com.example.harmoney.domain.models.CategoryIcons
+import com.example.harmoney.domain.models.CategoryType
+
+class CategoryDBConverterImpl : CategoryDBConverter {
+    override fun map(category: Category): CategoryEntity {
+        return CategoryEntity(
+            id = category.id,
+            name = category.name,
+            typeId = category.type.id,
+            iconId = category.icon.icon.id,
+            iconColorId = category.icon.color.id,
+            createdAt = category.createdAt,
+            userOrder = category.userOrder
+        )
+    }
+
+    override fun map(category: CategoryEntity): Category {
+        return Category(
+            id = category.id,
+            name = category.name,
+            type = CategoryType.fromId(category.typeId),
+            icon = CategoryIcon(
+                icon = CategoryIcons.fromId(category.iconId),
+                color = CategoryColors.fromId(category.iconColorId)
+            ),
+            createdAt = category.createdAt,
+            userOrder = category.userOrder
+        )
+    }
+
+    override fun map(categoryList: List<CategoryEntity>): List<Category> {
+        return categoryList.map { map(it) }
+    }
+}

--- a/app/src/main/java/com/example/harmoney/data/category/dao/CategoryDao.kt
+++ b/app/src/main/java/com/example/harmoney/data/category/dao/CategoryDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
 import com.example.harmoney.data.category.entity.CategoryEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CategoryDao {
@@ -24,10 +25,13 @@ interface CategoryDao {
     suspend fun getCategory(id: Long): CategoryEntity?
 
     @Query("SELECT * FROM category WHERE name = :name AND typeId = :categoryTypeId")
-    suspend fun getCategory(name: String, categoryTypeId: Long) : CategoryEntity?
+    suspend fun getCategory(name: String, categoryTypeId: Long): CategoryEntity?
 
     @Query("SELECT * FROM category WHERE typeId = :categoryTypeId")
-    suspend fun getCategoryList(categoryTypeId: Long): List<CategoryEntity>?
+    fun getCategoryList(categoryTypeId: Long): Flow<List<CategoryEntity>?>
+
+    @Query("UPDATE category SET userOrder = :newUserOrder WHERE id = :categoryId")
+    suspend fun updateCategoryUserOrder(categoryId: Long, newUserOrder: Double)
 
     // Если вставляем категорию в конец списка
     @Query("SELECT MAX(userOrder) FROM category WHERE typeId = :categoryTypeId")

--- a/app/src/main/java/com/example/harmoney/data/category/impl/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/harmoney/data/category/impl/CategoryRepositoryImpl.kt
@@ -1,0 +1,141 @@
+package com.example.harmoney.data.category.impl
+
+import android.util.Log
+import androidx.sqlite.SQLiteException
+import com.example.harmoney.core.util.Resource
+import com.example.harmoney.data.category.converter.CategoryDBConverter
+import com.example.harmoney.data.category.dao.CategoryDao
+import com.example.harmoney.domain.category.api.reposiory.CategoryRepository
+import com.example.harmoney.domain.category.models.CategoryFailure
+import com.example.harmoney.domain.models.Category
+import com.example.harmoney.domain.models.CategoryType
+import com.example.harmoney.domain.models.SortOption
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class CategoryRepositoryImpl(
+    private val categoryDao: CategoryDao,
+    private val categoryDBConverter: CategoryDBConverter,
+) : CategoryRepository {
+    // для корректной работы updateCategoryUserOrder
+    private val sortingDirection = USER_ORDER_IN_ASCENDING_ORDER
+
+    override suspend fun addCategory(category: Category): Resource<Unit, CategoryFailure> {
+        return try {
+            categoryDao.insertCategory(categoryDBConverter.map(category))
+            Resource.Success(Unit)
+        } catch (e: SQLiteException) {
+            Log.e(DATABASE_TAG, "Error when inserting category: ${e.message}", e)
+            Resource.Error(CategoryFailure.DatabaseError)
+        }
+    }
+
+    override suspend fun checkCategoryAlreadyExists(
+        categoryName: String,
+        categoryType: CategoryType
+    ): Resource<Boolean, CategoryFailure> {
+        return try {
+            val category = categoryDao.getCategory(categoryName, categoryType.id)
+            Resource.Success(category != null)
+        } catch (e: SQLiteException) {
+            Log.e(
+                DATABASE_TAG,
+                "Error when getting category (checkCategoryAlreadyExists): ${e.message}",
+                e
+            )
+            Resource.Error(CategoryFailure.DatabaseError)
+        }
+    }
+
+    override suspend fun deleteCategory(category: Category): Resource<Unit, CategoryFailure> {
+        return try {
+            categoryDao.deleteCategory(categoryDBConverter.map(category))
+            Resource.Success(Unit)
+        } catch (e: SQLiteException) {
+            Log.e(DATABASE_TAG, "Error when deleting category: ${e.message}", e)
+            Resource.Error(CategoryFailure.DatabaseError)
+        }
+    }
+
+    override suspend fun getCategory(categoryId: Long): Resource<Category, CategoryFailure> {
+        return try {
+            val category = categoryDao.getCategory(categoryId)
+            if (category != null) {
+                Resource.Success(categoryDBConverter.map(category))
+            } else {
+                Resource.Error(CategoryFailure.BadRequest)
+            }
+        } catch (e: SQLiteException) {
+            Log.e(DATABASE_TAG, "Error when getting category: ${e.message}", e)
+            Resource.Error(CategoryFailure.DatabaseError)
+        }
+    }
+
+    override fun getCategoryList(categoryType: CategoryType, sortOption: SortOption)
+            : Flow<Resource<List<Category>, CategoryFailure>> =
+        categoryDao.getCategoryList(categoryType.id)
+            .map { entities ->
+                val categories = entities ?: emptyList()
+                val sortedCategories = when (sortOption) {
+                    SortOption.ALPHABET -> categories.sortedBy { it.name }
+                    SortOption.TIME_CREATED -> categories.sortedBy { it.createdAt }
+                    SortOption.USER_ORDER -> {
+                        // для корректной работы updateCategoryUserOrder
+                        if (sortingDirection == USER_ORDER_IN_ASCENDING_ORDER) {
+                            categories.sortedBy { it.userOrder }
+                        } else {
+                            categories.sortedByDescending { it.userOrder }
+                        }
+                    }
+                }
+                Resource.Success(categoryDBConverter.map(sortedCategories))
+            }.catch { e ->
+                Log.e(DATABASE_TAG, "Error when getting categoryList: ${e.message}", e)
+                Resource.Error(CategoryFailure.DatabaseError)
+            }
+
+    override suspend fun updateCategory(category: Category): Resource<Unit, CategoryFailure> {
+        return try {
+            categoryDao.updateCategory(categoryDBConverter.map(category))
+            Resource.Success(Unit)
+        } catch (e: SQLiteException) {
+            Log.e(DATABASE_TAG, "Error when updating category: ${e.message}", e)
+            Resource.Error(CategoryFailure.DatabaseError)
+        }
+    }
+
+    override suspend fun updateCategoryUsedOrder(
+        categoryId: Long,
+        prevCategory: Category?,
+        nextCategory: Category?
+    ): Resource<Unit, CategoryFailure> {
+        return try {
+            val newUserOrder = when {
+                prevCategory == null && nextCategory == null -> USER_ORDER_STEP
+                prevCategory == null -> {
+                    nextCategory!!.userOrder - sortingDirection * USER_ORDER_STEP
+                }
+
+                nextCategory == null -> prevCategory.userOrder + sortingDirection * USER_ORDER_STEP
+                else -> (prevCategory.userOrder + nextCategory.userOrder) / 2.0
+            }
+            categoryDao.updateCategoryUserOrder(categoryId, newUserOrder)
+            Resource.Success(Unit)
+        } catch (e: SQLiteException) {
+            Log.e(
+                DATABASE_TAG,
+                "Error when updating category user order: ${e.message}",
+                e
+            )
+            Resource.Error(CategoryFailure.DatabaseError)
+        }
+    }
+
+    companion object {
+        private const val DATABASE_TAG = "HarmApp_CategoryDB"
+        const val USER_ORDER_STEP = 100.0
+        const val USER_ORDER_IN_ASCENDING_ORDER = 1 // значение не менять
+        const val USER_ORDER_IN_DESCENDING_ORDER = -1 // значение не менять
+    }
+}

--- a/app/src/main/java/com/example/harmoney/data/core/TransactionWithCategory.kt
+++ b/app/src/main/java/com/example/harmoney/data/core/TransactionWithCategory.kt
@@ -1,6 +1,7 @@
-package com.example.harmoney.data.category.entity
+package com.example.harmoney.data.core
 
 import androidx.room.Embedded
+import com.example.harmoney.data.category.entity.CategoryEntity
 import com.example.harmoney.data.transaction.entity.TransactionEntity
 
 data class TransactionWithCategory(

--- a/app/src/main/java/com/example/harmoney/data/transaction/dao/TransactionDao.kt
+++ b/app/src/main/java/com/example/harmoney/data/transaction/dao/TransactionDao.kt
@@ -6,7 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import com.example.harmoney.data.category.entity.TransactionWithCategory
+import com.example.harmoney.data.core.TransactionWithCategory
 import com.example.harmoney.data.transaction.entity.TransactionEntity
 
 @Dao

--- a/app/src/main/java/com/example/harmoney/domain/category/api/reposiory/CategoryRepository.kt
+++ b/app/src/main/java/com/example/harmoney/domain/category/api/reposiory/CategoryRepository.kt
@@ -4,6 +4,7 @@ import com.example.harmoney.core.util.Resource
 import com.example.harmoney.domain.category.models.CategoryFailure
 import com.example.harmoney.domain.models.Category
 import com.example.harmoney.domain.models.CategoryType
+import com.example.harmoney.domain.models.SortOption
 import kotlinx.coroutines.flow.Flow
 
 interface CategoryRepository {
@@ -15,7 +16,8 @@ interface CategoryRepository {
 
     suspend fun getCategory(categoryId: Long): Resource<Category, CategoryFailure>
 
-    fun getCategoryList(categoryType: CategoryType): Flow<Resource<List<Category>, CategoryFailure>>
+    fun getCategoryList(categoryType: CategoryType, sortOption: SortOption)
+            : Flow<Resource<List<Category>, CategoryFailure>>
 
     suspend fun updateCategoryUsedOrder(
         categoryId: Long,
@@ -26,5 +28,5 @@ interface CategoryRepository {
     suspend fun checkCategoryAlreadyExists(
         categoryName: String,
         categoryType: CategoryType
-    ): Flow<Resource<Boolean, CategoryFailure>>
+    ): Resource<Boolean, CategoryFailure>
 }

--- a/app/src/main/java/com/example/harmoney/domain/category/api/useCase/CheckCategoryAlreadyExistsUseCase.kt
+++ b/app/src/main/java/com/example/harmoney/domain/category/api/useCase/CheckCategoryAlreadyExistsUseCase.kt
@@ -3,11 +3,10 @@ package com.example.harmoney.domain.category.api.useCase
 import com.example.harmoney.core.util.Resource
 import com.example.harmoney.domain.category.models.CategoryFailure
 import com.example.harmoney.domain.models.CategoryType
-import kotlinx.coroutines.flow.Flow
 
 interface CheckCategoryAlreadyExistsUseCase {
     suspend fun execute(
         categoryName: String,
         categoryType: CategoryType
-    ): Flow<Resource<Boolean, CategoryFailure>>
+    ): Resource<Boolean, CategoryFailure>
 }

--- a/app/src/main/java/com/example/harmoney/domain/category/impl/CheckCategoryAlreadyExistsUseCaseImpl.kt
+++ b/app/src/main/java/com/example/harmoney/domain/category/impl/CheckCategoryAlreadyExistsUseCaseImpl.kt
@@ -5,14 +5,13 @@ import com.example.harmoney.domain.category.api.reposiory.CategoryRepository
 import com.example.harmoney.domain.category.api.useCase.CheckCategoryAlreadyExistsUseCase
 import com.example.harmoney.domain.category.models.CategoryFailure
 import com.example.harmoney.domain.models.CategoryType
-import kotlinx.coroutines.flow.Flow
 
 class CheckCategoryAlreadyExistsUseCaseImpl(private val repository: CategoryRepository) :
     CheckCategoryAlreadyExistsUseCase {
     override suspend fun execute(
         categoryName: String,
         categoryType: CategoryType
-    ): Flow<Resource<Boolean, CategoryFailure>> {
+    ): Resource<Boolean, CategoryFailure> {
         return repository.checkCategoryAlreadyExists(categoryName, categoryType)
     }
 }

--- a/app/src/main/java/com/example/harmoney/domain/category/impl/GetCategoryListUseCaseImpl.kt
+++ b/app/src/main/java/com/example/harmoney/domain/category/impl/GetCategoryListUseCaseImpl.kt
@@ -6,12 +6,20 @@ import com.example.harmoney.domain.category.api.useCase.GetCategoryListUseCase
 import com.example.harmoney.domain.category.models.CategoryFailure
 import com.example.harmoney.domain.models.Category
 import com.example.harmoney.domain.models.CategoryType
+import com.example.harmoney.domain.settings.categorySortingMode.api.repository.CategorySortOptionRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
 
-class GetCategoryListUseCaseImpl(private val repository: CategoryRepository) :
-    GetCategoryListUseCase {
+class GetCategoryListUseCaseImpl(
+    private val categoryRepository: CategoryRepository,
+    private val sortOptionRepository: CategorySortOptionRepository
+) : GetCategoryListUseCase {
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun execute(categoryType: CategoryType)
-            : Flow<Resource<List<Category>, CategoryFailure>> {
-        return repository.getCategoryList(categoryType)
-    }
+            : Flow<Resource<List<Category>, CategoryFailure>> =
+        sortOptionRepository.getSortOption()
+            .flatMapLatest { sortOption ->
+                categoryRepository.getCategoryList(categoryType, sortOption)
+            }
 }

--- a/app/src/main/java/com/example/harmoney/domain/category/models/CategoryFailure.kt
+++ b/app/src/main/java/com/example/harmoney/domain/category/models/CategoryFailure.kt
@@ -4,5 +4,6 @@ import com.example.harmoney.core.util.Failure
 
 sealed interface CategoryFailure : Failure {
     data object BadRequest : CategoryFailure
+    data object DatabaseError: CategoryFailure
     data class Unknown(val cause: Throwable? = null) : CategoryFailure
 }

--- a/app/src/main/java/com/example/harmoney/domain/settings/categorySortingMode/api/repository/CategorySortOptionRepository.kt
+++ b/app/src/main/java/com/example/harmoney/domain/settings/categorySortingMode/api/repository/CategorySortOptionRepository.kt
@@ -8,18 +8,3 @@ interface CategorySortOptionRepository {
 
     suspend fun setSortOption(sortingOption: SortOption)
 }
-
-// предлагается такое использование
-/*class GetCategoriesUseCaseImpl(
-    private val categoryRepository: CategoryRepository,
-    private val sortOptionRepository: CategorySortingRepository,
-) : GetCategoriesUseCase {
-    override fun invoke(): Flow<List<Category>> =
-        combine(
-            sortOptionRepository.getSortOption()
-        ) {sortOption ->
-            sortOption
-        }.flatMapLatest {sortOption ->
-            categoryRepository.getCategories(sortOption)
-        }
-}*/


### PR DESCRIPTION
Было добавлено:
1. `CategoryDBConverter` - конвертер для моделей `CategoryEntitiy` и `Category`
2. `CategoryRepositoryImpl`

Было изменено:
1. `CategoryDao` - добавлена функция `updateCategoryUserOrder`
2. `CheckCategoryAlreadyExistsUseCase` - изменено возвращаемое значение. Убрала Flow, т.к. здесь не нужно автоматическое обновление данных.
3. `GetCategoryListUseCaseImpl` - добавлено использование `CategorySortOptionRepository` чтобы выводить отсортированный список категорий (но не передавать режим сортировки от viewModel экранов, где режим сортировки не настраивается).
4. `dataModule`, `repositoryModule`, `useCaseModule` - добавлены зависимости 
5. `CategoryFailure` - добавлен тип ошибки DatabaseError